### PR TITLE
build.gradle cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,7 @@
 plugins {
-	id "java"
-	id "eclipse"
-	id "idea"
-	id "fabric-loom" version "0.2.6-SNAPSHOT"
+	id "fabric-loom" version "0.2.7-SNAPSHOT"
 	id "maven-publish"
-	id "com.jfrog.artifactory" version "4.9.0"
+	id "com.jfrog.artifactory" version "4.15.2"
 }
 
 sourceCompatibility = 1.8
@@ -22,8 +19,6 @@ minecraft {
 }
 
 repositories {
-	mavenCentral()
-	maven { url "http://maven.fabricmc.net/" } // Fabric maven - home of Fabric API and ModMenu
 	maven { url "https://server.bbkr.space/artifactory/libs-release" } // Cotton maven - home of Cotton projects
 	maven { url "https://maven.abusedmaster.xyz" } // NerdHub maven - home of Cardinal Components
 }
@@ -58,7 +53,7 @@ tasks.withType(JavaCompile) {
 // if it is present.
 // If you remove this task, sources will not be generated.
 task sourcesJar(type: Jar, dependsOn: classes) {
-	classifier = "sources"
+	archiveClassifier = "sources"
 	from sourceSets.main.allSource
 }
 
@@ -71,18 +66,15 @@ publishing {
 	publications {
 		maven(MavenPublication) {
 			// add all the jars that should be included when publishing to maven
-			//artifact(jar) {
-			//	builtBy remapJar
-			//}
-			artifact ("${project.buildDir.absolutePath}/libs/${archivesBaseName}-${project.version}.jar") { //release jar - file location not provided anywhere in loom
+			artifact(remapJar) {
 				classifier null
 				builtBy remapJar
 			}
 
-			artifact ("${project.buildDir.absolutePath}/libs/${archivesBaseName}-${project.version}-dev.jar") { //release jar - file location not provided anywhere in loom
+			/*artifact ("${project.buildDir.absolutePath}/libs/${archivesBaseName}-${project.version}-dev.jar") { //release jar - file location not provided anywhere in loom
 				classifier "dev"
 				builtBy remapJar
-			}
+			}*/
 
 			artifact(sourcesJar) {
 				builtBy remapSourcesJar


### PR DESCRIPTION
Closes #1.

- Updated Loom to newest stable version, 0.2.7
- Updated the Artifactory plugin to 4.15.2 to support newer Gradle
- Removed unnecessary plugin declarations
  - Loom applies `java`, `idea` and `eclipse`
- Removed unnecessary repository declarations
  - Loom adds `mavenCentral()` and the Fabric maven
- Replaced usage of deprecated property in sourcesJar
- Updated publication config to match Fabric example mod